### PR TITLE
chore: fix setup.py dependencies resolving

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 import setuptools
-from binance import __version__
+
+def get_version(rel_path):
+    with open(rel_path) as fp:
+        for line in fp:
+            if line.startswith('__version__'):
+                delim = '"' if '"' in line else "'"
+                return line.split(delim)[1]
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -9,7 +15,7 @@ with open("requirements.txt") as fh:
 
 setuptools.setup(
     name="binance.py",
-    version=__version__,
+    version=get_version("binance/__init__.py"),
     author="Th0rgal",
     author_email="thomas.marchand@tuta.io",
     description="A python3 binance API wrapper powered by modern technologies such as asyncio",


### PR DESCRIPTION
After #18 I decided not to wait for the new release, but to add repo to my poetry config.
But I caught the bug with packaging :D

Before install of package dependencies it checks for version and crashes then.

This PR fixes it.
<details>

<summary>Poetry output</summary>

```bash
zsh % poetry add git+https://github.com/Th0rgal/binance.py 

  PackageInfoError

  Unable to determine package info for path: /var/folders/s5/fsyqmxc5687753yl5sxrg4t00000gp/T/pypoetry-git-binance.py929c0ots
  
  Fallback egg_info generation failed.
  
  Command ['/var/folders/s5/fsyqmxc5687753yl5sxrg4t00000gp/T/tmpjwavjsth/.venv/bin/python', 'setup.py', 'egg_info'] errored with the following return code 1, and output: 
  Traceback (most recent call last):
    File "/private/var/folders/s5/fsyqmxc5687753yl5sxrg4t00000gp/T/pypoetry-git-binance.py929c0ots/setup.py", line 2, in <module>
      from binance import __version__
    File "/private/var/folders/s5/fsyqmxc5687753yl5sxrg4t00000gp/T/pypoetry-git-binance.py929c0ots/binance/__init__.py", line 19, in <module>
      from .client import Client
    File "/private/var/folders/s5/fsyqmxc5687753yl5sxrg4t00000gp/T/pypoetry-git-binance.py929c0ots/binance/client.py", line 1, in <module>
      from .http import HttpClient
    File "/private/var/folders/s5/fsyqmxc5687753yl5sxrg4t00000gp/T/pypoetry-git-binance.py929c0ots/binance/http.py", line 4, in <module>
      import aiohttp
  ModuleNotFoundError: No module named 'aiohttp'

  at ~/.pyenv/versions/3.9.0/lib/python3.9/site-packages/poetry/inspection/info.py:502 in _pep517_metadata
      498│                 try:
      499│                     venv.run("python", "setup.py", "egg_info")
      500│                     return cls.from_metadata(path)
      501│                 except EnvCommandError as fbe:
    → 502│                     raise PackageInfoError(
      503│                         path, "Fallback egg_info generation failed.", fbe
      504│                     )
      505│                 finally:
      506│                     os.chdir(cwd.as_posix())```